### PR TITLE
Place optional params last

### DIFF
--- a/classes/class-ledyer-om-main.php
+++ b/classes/class-ledyer-om-main.php
@@ -37,7 +37,7 @@ class Ledyer_Order_Management_For_WooCommerce {
 		add_action(
 			'woocommerce_order_status_completed',
 			function ( $order_id, $action = false ) {
-				lom_capture_ledyer_order( $order_id, $action, $this->api );
+				lom_capture_ledyer_order( $order_id, $this->api, $action );
 			}
 		);
 
@@ -65,7 +65,7 @@ class Ledyer_Order_Management_For_WooCommerce {
 		add_action(
 			'woocommerce_order_status_cancelled',
 			function ( $order_id, $action = false ) {
-				lom_cancel_ledyer_order( $order_id, $action, $this->api );
+				lom_cancel_ledyer_order( $order_id, $this->api, $action );
 			}
 		);
 
@@ -73,7 +73,7 @@ class Ledyer_Order_Management_For_WooCommerce {
 		add_action(
 			'woocommerce_saved_order_items',
 			function ( $order_id, $action = false ) {
-				lom_edit_ledyer_order( $order_id, $action, $this->api, 'order' );
+				lom_edit_ledyer_order( $order_id, $this->api, 'order', $action );
 			}
 		);
 
@@ -85,7 +85,7 @@ class Ledyer_Order_Management_For_WooCommerce {
 				if ( ! is_admin() ) {
 					return;
 				}
-				lom_edit_ledyer_order( $order_id, $action, $this->api, 'customer' );
+				lom_edit_ledyer_order( $order_id, $this->api, 'customer', $action );
 			},
 			55,
 			1 // Priority higher than 50, since that is the priority we use to save the fields after validation is done. We don't want to sync with Ledyer if local Woo validation of the fields fail.

--- a/includes/lom-cancel.php
+++ b/includes/lom-cancel.php
@@ -9,7 +9,7 @@
 	 * @param bool                     $action If this was triggered by an action.
 	 * @param $api The lom api instance
 	 */
-function lom_cancel_ledyer_order( $order_id, $action = false, $api ) {
+function lom_cancel_ledyer_order( $order_id, $api, $action = false ) {
 	$options = get_option( 'lom_settings' );
 
 	// If the cancel is not enabled in lom-settings

--- a/includes/lom-capture.php
+++ b/includes/lom-capture.php
@@ -9,7 +9,7 @@
  * @param bool                     $action If this was triggered by an action.
  * @param $api The lom api instance
  */
-function lom_capture_ledyer_order( $order_id, $action = false, $api ) {
+function lom_capture_ledyer_order( $order_id, $api, $action = false ) {
 	$options                         = get_option( 'lom_settings', array() );
 	$auto_capture                    = $options['lom_auto_capture'] ?? 'yes';
 	$lom_status_mapping_ledyer_error = $options['lom_status_mapping_ledyer_error'] ?? 'wc-on-hold';

--- a/includes/lom-edit.php
+++ b/includes/lom-edit.php
@@ -10,7 +10,7 @@
  * @param $api The lom api instance
  * @param string $syncType order or customer
  */
-function lom_edit_ledyer_order($order_id, $action = false, $api, $syncType) {
+function lom_edit_ledyer_order($order_id, $api, $syncType, $action = false) {
     $options = get_option('lom_settings');
     if ('no' === $options['lom_auto_update']) {
         return;


### PR DESCRIPTION
Regarding this notice: "PHP Deprecated: Optional parameter ... declared before required parameter ... is implicitly treated as a required parameter"