### PR TITLE
Add & implement numeric conversion helper

### DIFF
--- a/classes/class-ledyer-om-order-mapper.php
+++ b/classes/class-ledyer-om-order-mapper.php
@@ -225,11 +225,11 @@ class OrderMapper {
 
 	private function get_item_total_amount( $order_line_item, $currency ) {
 		if ( 'shipping' === $order_line_item->get_type() || 'fee' === $order_line_item->get_type() ) {
-			$item_total_amount = ledyer_ensure_numeric( $order_line_item->get_total() ) + $order_line_item->get_total_tax();
+			$item_total_amount = ledyer_om_ensure_numeric( $order_line_item->get_total() ) + $order_line_item->get_total_tax();
 		} elseif ( 'coupon' === $order_line_item->get_type() ) {
 			$item_total_amount = $order_line_item->get_discount();
 		} else {
-			$item_total_amount = ledyer_ensure_numeric( $order_line_item->get_total() ) + $order_line_item->get_total_tax();
+			$item_total_amount = ledyer_om_ensure_numeric( $order_line_item->get_total() ) + $order_line_item->get_total_tax();
 		}
 		return $this->amount_to_minor( $item_total_amount, $currency );
 	}

--- a/classes/class-ledyer-om-order-mapper.php
+++ b/classes/class-ledyer-om-order-mapper.php
@@ -225,11 +225,11 @@ class OrderMapper {
 
 	private function get_item_total_amount( $order_line_item, $currency ) {
 		if ( 'shipping' === $order_line_item->get_type() || 'fee' === $order_line_item->get_type() ) {
-			$item_total_amount = $order_line_item->get_total() + $order_line_item->get_total_tax();
+			$item_total_amount = ledyer_ensure_numeric( $order_line_item->get_total() ) + $order_line_item->get_total_tax();
 		} elseif ( 'coupon' === $order_line_item->get_type() ) {
 			$item_total_amount = $order_line_item->get_discount();
 		} else {
-			$item_total_amount = $order_line_item->get_total() + $order_line_item->get_total_tax();
+			$item_total_amount = ledyer_ensure_numeric( $order_line_item->get_total() ) + $order_line_item->get_total_tax();
 		}
 		return $this->amount_to_minor( $item_total_amount, $currency );
 	}

--- a/includes/lom-functions.php
+++ b/includes/lom-functions.php
@@ -46,3 +46,33 @@ function lom_get_order_id_by_ledyer_order_id( $ledyer_order_id ) {
 
 	return $order->get_id() ?? 0;
 }
+
+/**
+ * Ensure that a value is numeric. If the value is not numeric, it will attempt to convert it.
+ * If the value is an empty value, it will be set to 0.
+ * If the value cannot be converted to a numeric value, it will return the default value.
+ *
+ * @param mixed     $value The value to ensure is numeric.
+ * @param float|int $default The default value to return if the value is not numeric and $throw_error is false. Default 0.
+ *
+ * @return float|int Returns the numeric value of the input, or the default value if the input is not numeric and cannot be converted.
+ */
+function ledyer_ensure_numeric( $value, $default = 0 ) {
+	if ( is_numeric( $value ) ) {
+		return floatval( $value );
+	}
+
+	// If the value is empty, return 0 instead of default to reflect that the value is not set.
+	if ( empty( $value ) ) {
+		return 0;
+	}
+
+	// Try to convert the value to a numeric value.
+	$converted_value = floatval( $value );
+
+	if ( is_numeric( $converted_value ) ) {
+		return $converted_value;
+	}
+
+	return $default; // Return the default value if the value is still not numeric.
+}

--- a/includes/lom-functions.php
+++ b/includes/lom-functions.php
@@ -57,7 +57,7 @@ function lom_get_order_id_by_ledyer_order_id( $ledyer_order_id ) {
  *
  * @return float|int Returns the numeric value of the input, or the default value if the input is not numeric and cannot be converted.
  */
-function ledyer_ensure_numeric( $value, $default = 0 ) {
+function ledyer_om_ensure_numeric( $value, $default = 0 ) {
 	if ( is_numeric( $value ) ) {
 		return floatval( $value );
 	}


### PR DESCRIPTION
Add a numeric conversion helper and implement for the shipping price, to ensure a numeric value. Resolves potential for fatal errors on order management, in cases where shipping option price is returned as a string value.